### PR TITLE
fix: refresh device list after detaching device

### DIFF
--- a/qubesadmin/devices.py
+++ b/qubesadmin/devices.py
@@ -84,6 +84,10 @@ class DeviceCollection:
             (obtained from :py:meth:`assignments`)
         """
         self._remove(assignment, "detach")
+        # refresh device list
+        assignment.backend_domain \
+            .run_service('qubes.VMShell', user='root') \
+            .communicate(input=b'partprobe\n')
 
     def assign(self, assignment: DeviceAssignment) -> None:
         """


### PR DESCRIPTION
This aims to fix [#9566](https://github.com/QubesOS/qubes-issues/issues/9566) but has two problems:

1. It only works via terminal, not the GUI and I'm not sure why.
2. I only tested it with the stable version of Qubes, and `device.py` has changed since then.

Below is the version I tested:

```python3
    def detach(self, device_assignment):
        """Detach (remove) device from domain.

        :param DeviceAssignment device_assignment: device to detach
            (obtained from :py:meth:`assignments`)
        """
        if not device_assignment.frontend_domain:
            device_assignment.frontend_domain = self._vm
        else:
            assert device_assignment.frontend_domain == self._vm, \
                "Trying to detach DeviceAssignment belonging to other domain"
        if device_assignment.devclass is None:
            device_assignment.devclass = self._class
        else:
            assert device_assignment.devclass == self._class

        self._vm.qubesd_call(None,
                             'admin.vm.device.{}.Detach'.format(self._class),
                             '{!s}+{!s}'.format(
                                 device_assignment.backend_domain,
                                 device_assignment.ident))

        # Zaz added:
        device_assignment.backend_domain \
            .run_service('qubes.VMShell', user='root') \
            .communicate(input=b'partprobe\n')
```